### PR TITLE
Add Error type and handling

### DIFF
--- a/spec/aes_spec.cr
+++ b/spec/aes_spec.cr
@@ -64,4 +64,22 @@ describe AES do
       prev = current
     end
   end
+
+  it "raises on failed decryption (corrupted data)" do
+    crypto = AES.new
+    encrypted = crypto.encrypt(STR1)
+    encrypted.shuffle!
+    expect_raises(AES::Error) do
+      crypto.decrypt(encrypted)
+    end
+  end
+
+  it "raises on failed decryption (wrong key)" do
+    crypto_bob = AES.new
+    encrypted = crypto_bob.encrypt(STR1)
+    crypto_alice = AES.new
+    expect_raises(AES::Error) do
+      crypto_alice.decrypt(encrypted)
+    end
+  end
 end

--- a/src/aes.cr
+++ b/src/aes.cr
@@ -36,6 +36,8 @@ lib LibCrypto
   fun evp_aes_192_cbc = EVP_aes_192_cbc : EvpCipher
   fun evp_aes_256_cbc = EVP_aes_256_cbc : EvpCipher
   fun evp_cipher_ctx_init = EVP_CIPHER_CTX_reset(c : EvpCipherCtx*) : LibC::Int
+  fun get_error = ERR_get_error : LibC::ULong
+  fun get_error_string = ERR_error_string(code : LibC::ULong, buf : Pointer(LibC::Char)) : Pointer(Char)
 end
 
 class AES
@@ -106,9 +108,15 @@ class AES
     c_len = data.size + LibCrypto::EVP_MAX_BLOCK_LENGTH
     f_len = 0
     ciphertext = Slice.new(c_len, 0u8)
-    LibCrypto.evp_encrypt_init_ex(pointerof(@encrypt_context), nil, nil, nil, nil)
-    LibCrypto.evp_encrypt_update(pointerof(@encrypt_context), ciphertext.to_unsafe, pointerof(c_len), data, data.size)
-    LibCrypto.evp_encrypt_final_ex(pointerof(@encrypt_context), ciphertext.to_unsafe + c_len, pointerof(f_len))
+    if LibCrypto.evp_encrypt_init_ex(pointerof(@encrypt_context), nil, nil, nil, nil) != 1
+      raise_ssl_error("evp_encrypt_init")
+    end
+    if LibCrypto.evp_encrypt_update(pointerof(@encrypt_context), ciphertext.to_unsafe, pointerof(c_len), data, data.size) != 1
+      raise_ssl_error("evp_encrypt_update")
+    end
+    if LibCrypto.evp_encrypt_final_ex(pointerof(@encrypt_context), ciphertext.to_unsafe + c_len, pointerof(f_len)) != 1
+      raise_ssl_error("evp_encrypt_final")
+    end
     ciphertext[0, f_len + c_len]
   end
 
@@ -121,14 +129,37 @@ class AES
     len = data.size
     f_len = 0
     plaintext = Slice.new(p_len, 0u8)
-    LibCrypto.evp_decrypt_init_ex(pointerof(@decrypt_context), nil, nil, nil, nil)
-    LibCrypto.evp_decrypt_update(pointerof(@decrypt_context), plaintext.to_unsafe, pointerof(p_len), data.to_unsafe, len)
-    LibCrypto.evp_decrypt_final_ex(pointerof(@decrypt_context), plaintext.to_unsafe + p_len, pointerof(f_len))
+    if LibCrypto.evp_decrypt_init_ex(pointerof(@decrypt_context), nil, nil, nil, nil) != 1
+      raise_ssl_error("evp_decrypt_init")
+    end
+    if LibCrypto.evp_decrypt_update(pointerof(@decrypt_context), plaintext.to_unsafe, pointerof(p_len), data.to_unsafe, len) != 1
+      raise_ssl_error("evp_decrypt_update")
+    end
+    if LibCrypto.evp_decrypt_final_ex(pointerof(@decrypt_context), plaintext.to_unsafe + p_len, pointerof(f_len)) != 1
+      raise_ssl_error("evp_decrypt_final")
+    end
     plaintext[0, p_len + f_len - nonce_size]
   end
 
   def decrypt(str : String)
     decrypt(str.as_slice)
+  end
+
+  class Error < Exception
+    getter call
+    getter code
+    getter reason
+
+    def initialize(@call : String, @code : UInt64, @reason : String)
+      super("OpenSSL returned an error: #{@reason} (function: #{call}, code: #{@code})")
+    end
+  end
+
+  private def raise_ssl_error(func : String)
+    code = LibCrypto.get_error
+    reason = LibCrypto.get_error_string(code, nil)
+    instance = Error.new(func, code, String.new(reason))
+    raise instance
   end
 end
 


### PR DESCRIPTION
This adds basic error checking to encrypt/decrypt using the return value
error flag, and the SSL error functions. It captures the name of the
function that failed, and the SSL error for the caller to handle.

Example error message:

    OpenSSL returned an error: error:06065064:digital envelope routines:EVP_DecryptFinal_ex:bad decrypt (function: evp_decrypt_final, code: 101077092) (AES::Error)