### PR TITLE
Tidying: remove patch, formatting

### DIFF
--- a/spec/aes_spec.cr
+++ b/spec/aes_spec.cr
@@ -18,14 +18,14 @@ describe AES do
   it "round trips in 256 bit mode" do
     1000.times do
       crypto = AES.new(256)
-      String.new(crypto.decrypt(crypto.encrypt(STR1.as_slice))).should eq STR1
+      String.new(crypto.decrypt(crypto.encrypt(STR1.to_slice))).should eq STR1
     end
   end
 
   it "round trips in 128 bit mode" do
     1000.times do
       crypto = AES.new(128)
-      String.new(crypto.decrypt(crypto.encrypt(STR1.as_slice))).should eq STR1
+      String.new(crypto.decrypt(crypto.encrypt(STR1.to_slice))).should eq STR1
     end
   end
 

--- a/src/aes.cr
+++ b/src/aes.cr
@@ -72,7 +72,7 @@ class AES
   end
 
   def initialize(key : String, iv : String, bits : Int32 = 256)
-    initialize(key.as_slice, iv.as_slice, bits)
+    initialize(key.to_slice, iv.to_slice, bits)
   end
 
   def initialize(key : Slice(UInt8), iv : Slice(UInt8), bits : Int32 = 256)
@@ -113,7 +113,7 @@ class AES
   end
 
   def encrypt(str : String)
-    encrypt(str.as_slice)
+    encrypt(str.to_slice)
   end
 
   def decrypt(data : Slice(UInt8))
@@ -128,13 +128,6 @@ class AES
   end
 
   def decrypt(str : String)
-    decrypt(str.as_slice)
-  end
-end
-
-class String
-  def as_slice
-    bts = bytes
-    Slice.new(bts.to_unsafe, bts.size)
+    decrypt(str.to_slice)
   end
 end

--- a/src/aes.cr
+++ b/src/aes.cr
@@ -47,8 +47,8 @@ class AES
   property nonce_size : Int32 = 2
 
   SUPPORTED_BITSIZES = [128, 192, 256]
-  READABLE_CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$%^&*()_+=-?/>.<,;:]}[{|".chars
-  CHARS = (0_u8..255_u8).to_a
+  READABLE_CHARS     = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$%^&*()_+=-?/>.<,;:]}[{|".chars
+  CHARS              = (0_u8..255_u8).to_a
 
   def self.generate_key(length = 32)
     key = ""
@@ -82,14 +82,14 @@ class AES
     LibCrypto.evp_cipher_ctx_init(de)
     case bits
     when 128
-      LibCrypto.evp_encrypt_init_ex(en, LibCrypto.evp_aes_128_cbc(), nil, key, iv)
-      LibCrypto.evp_decrypt_init_ex(de, LibCrypto.evp_aes_128_cbc(), nil, key, iv)
+      LibCrypto.evp_encrypt_init_ex(en, LibCrypto.evp_aes_128_cbc, nil, key, iv)
+      LibCrypto.evp_decrypt_init_ex(de, LibCrypto.evp_aes_128_cbc, nil, key, iv)
     when 192
-      LibCrypto.evp_encrypt_init_ex(en, LibCrypto.evp_aes_192_cbc(), nil, key, iv)
-      LibCrypto.evp_decrypt_init_ex(de, LibCrypto.evp_aes_192_cbc(), nil, key, iv)
+      LibCrypto.evp_encrypt_init_ex(en, LibCrypto.evp_aes_192_cbc, nil, key, iv)
+      LibCrypto.evp_decrypt_init_ex(de, LibCrypto.evp_aes_192_cbc, nil, key, iv)
     when 256
-      LibCrypto.evp_encrypt_init_ex(en, LibCrypto.evp_aes_256_cbc(), nil, key, iv)
-      LibCrypto.evp_decrypt_init_ex(de, LibCrypto.evp_aes_256_cbc(), nil, key, iv)
+      LibCrypto.evp_encrypt_init_ex(en, LibCrypto.evp_aes_256_cbc, nil, key, iv)
+      LibCrypto.evp_decrypt_init_ex(de, LibCrypto.evp_aes_256_cbc, nil, key, iv)
     else
       raise "bits must be one of #{SUPPORTED_BITSIZES}"
     end


### PR DESCRIPTION
The `as_slice` patch creates an unecessary copy - an immutable slice can be obtained of the underlying string buffer (cheap) with [`String#to_slice`](https://github.com/crystal-lang/crystal/blob/5999ae29b/src/string.cr#L4792-L4797).

The formatter is applied to remove empty method call brackets and const expression alignment.